### PR TITLE
Fixed issue where tests were not able to run in parallel because they overwrote the same filesystem resource.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ tnt_project_New(${PROJECT_NAME}
 # Find and install dependencies
 tnt_project_ConanInstall(${PROJECT_NAME})
 include(${CMAKE_CURRENT_BINARY_DIR}/conan_paths.cmake)
+find_package(Boost MODULE REQUIRED)
 find_package(Catch2 CONFIG REQUIRED)
 find_package(dsp CONFIG REQUIRED)
 find_package(math CONFIG REQUIRED)

--- a/conanfile.py
+++ b/conanfile.py
@@ -2,12 +2,13 @@ from conans import ConanFile, CMake, tools
 
 class CppAudio(ConanFile):
     author = "TNT Coders <tnt-coders@googlegroups.com>"
-    build_requires = ["catch2/3.0.0-1@tnt-coders/stable",
+    build_requires = ["boost/1.75.0",
+                      "catch2/3.0.0-1@tnt-coders/stable",
                       "math/1.0.0@tnt-coders/stable"]
-    default_options = {"shared": False}
+    default_options = {"boost:header_only": True, "shared": False}
     description = "C++ library for reading and writing audio files"
     exports_sources = "CMakeLists.txt", "docs/*", "include/*", "src/*", "test/*"
-    generators = "cmake", "cmake_paths"
+    generators = "cmake", "cmake_paths", "cmake_find_package"
     license = "GNU Lesser General Public License v3.0"
     name = "audio"
     options = {"shared": [True, False]}
@@ -33,9 +34,5 @@ class CppAudio(ConanFile):
 
     def _configure_cmake(self):
         cmake = CMake(self)
-
-        # Prevent parallel tests (tests use shared file system resources)
-        cmake.parallel = False
-
         cmake.configure()
         return cmake

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(${PROJECT_NAME}_test
     tnt::${PROJECT_NAME}
     tnt::dsp
     tnt::math
+    Boost::headers
     Catch2::Catch2WithMain
 )
 

--- a/test/wave_file.cpp
+++ b/test/wave_file.cpp
@@ -1,5 +1,6 @@
 #include "config.hpp"
 
+#include <boost/type_index.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
@@ -234,12 +235,16 @@ TEMPLATE_TEST_CASE("WaveFile::write", "[file][WaveFile][write]", float, double)
 {
     const auto signal = signal_from_config<TestType>("data/wave_files/signal.dat");
 
+    // Need to use a different file name for each type so tests can run in parallel without conflict
+    const auto test_type = boost::typeindex::type_id<TestType>().pretty_name();
+    const auto file      = "data/wave_files/tmp-" + test_type + ".wav";
+
     SECTION("PCM_U8")
     {
         constexpr auto scale  = (static_cast<size_t>(std::numeric_limits<uint8_t>::max()) + 1) / 2;
         constexpr auto margin = static_cast<TestType>(1) / scale;
 
-        audio::WaveFile<TestType> w("data/wave_files/tmp.wav");
+        audio::WaveFile<TestType> w(file);
         w.write(signal, audio::WaveFormat::PCM, audio::WaveDataType::UINT8);
 
         CHECK(w.duration() == signal.duration());
@@ -248,6 +253,8 @@ TEMPLATE_TEST_CASE("WaveFile::write", "[file][WaveFile][write]", float, double)
         CHECK(w.channels() == signal.channels());
 
         const auto s = w.read();
+
+        std::filesystem::remove(file);
 
         REQUIRE(s.size() == signal.size());
         REQUIRE(s.channels() == signal.channels());
@@ -266,7 +273,7 @@ TEMPLATE_TEST_CASE("WaveFile::write", "[file][WaveFile][write]", float, double)
         constexpr auto scale  = static_cast<size_t>(std::numeric_limits<int16_t>::max()) + 1;
         constexpr auto margin = static_cast<TestType>(1) / scale;
 
-        audio::WaveFile<TestType> w("data/wave_files/tmp.wav");
+        audio::WaveFile<TestType> w(file);
         w.write(signal, audio::WaveFormat::PCM, audio::WaveDataType::INT16);
 
         CHECK(w.duration() == signal.duration());
@@ -275,6 +282,8 @@ TEMPLATE_TEST_CASE("WaveFile::write", "[file][WaveFile][write]", float, double)
         CHECK(w.channels() == signal.channels());
 
         const auto s = w.read();
+
+        std::filesystem::remove(file);
 
         REQUIRE(s.size() == signal.size());
         REQUIRE(s.channels() == signal.channels());
@@ -290,7 +299,7 @@ TEMPLATE_TEST_CASE("WaveFile::write", "[file][WaveFile][write]", float, double)
 
     SECTION("PCM_24")
     {
-        audio::WaveFile<TestType> w("data/wave_files/tmp.wav");
+        audio::WaveFile<TestType> w(file);
         w.write(signal, audio::WaveFormat::PCM, audio::WaveDataType::INT24);
 
         CHECK(w.duration() == signal.duration());
@@ -299,6 +308,8 @@ TEMPLATE_TEST_CASE("WaveFile::write", "[file][WaveFile][write]", float, double)
         CHECK(w.channels() == signal.channels());
 
         const auto s = w.read();
+
+        std::filesystem::remove(file);
 
         REQUIRE(s.size() == signal.size());
         REQUIRE(s.channels() == signal.channels());
@@ -314,7 +325,7 @@ TEMPLATE_TEST_CASE("WaveFile::write", "[file][WaveFile][write]", float, double)
 
     SECTION("PCM_32")
     {
-        audio::WaveFile<TestType> w("data/wave_files/tmp.wav");
+        audio::WaveFile<TestType> w(file);
         w.write(signal, audio::WaveFormat::PCM, audio::WaveDataType::INT32);
 
         CHECK(w.duration() == signal.duration());
@@ -323,6 +334,8 @@ TEMPLATE_TEST_CASE("WaveFile::write", "[file][WaveFile][write]", float, double)
         CHECK(w.channels() == signal.channels());
 
         const auto s = w.read();
+
+        std::filesystem::remove(file);
 
         REQUIRE(s.size() == signal.size());
         REQUIRE(s.channels() == signal.channels());
@@ -338,7 +351,7 @@ TEMPLATE_TEST_CASE("WaveFile::write", "[file][WaveFile][write]", float, double)
 
     SECTION("FLOAT")
     {
-        audio::WaveFile<TestType> w("data/wave_files/tmp.wav");
+        audio::WaveFile<TestType> w(file);
         w.write(signal, audio::WaveFormat::IEEE_FLOAT, audio::WaveDataType::FLOAT);
 
         CHECK(w.duration() == signal.duration());
@@ -347,6 +360,8 @@ TEMPLATE_TEST_CASE("WaveFile::write", "[file][WaveFile][write]", float, double)
         CHECK(w.channels() == signal.channels());
 
         const auto s = w.read();
+
+        std::filesystem::remove(file);
 
         REQUIRE(s.size() == signal.size());
         REQUIRE(s.channels() == signal.channels());
@@ -362,7 +377,7 @@ TEMPLATE_TEST_CASE("WaveFile::write", "[file][WaveFile][write]", float, double)
 
     SECTION("DOUBLE")
     {
-        audio::WaveFile<TestType> w("data/wave_files/tmp.wav");
+        audio::WaveFile<TestType> w(file);
         w.write(signal, audio::WaveFormat::IEEE_FLOAT, audio::WaveDataType::DOUBLE);
 
         CHECK(w.duration() == signal.duration());
@@ -371,6 +386,8 @@ TEMPLATE_TEST_CASE("WaveFile::write", "[file][WaveFile][write]", float, double)
         CHECK(w.channels() == signal.channels());
 
         const auto s = w.read();
+
+        std::filesystem::remove(file);
 
         REQUIRE(s.size() == signal.size());
         REQUIRE(s.channels() == signal.channels());


### PR DESCRIPTION
resolves #7 